### PR TITLE
Bump action runtime to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: true
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
GitHub Actions runners default to Node 24 on June 2, 2026; JS actions declaring `runs.using: node20` will fail. Bumps the runtime declaration to `node24`. No source changes — bundled `dist/index.js` is unchanged.

Tracking: Doist/platform-backlog#1385.